### PR TITLE
feat: github action for S3 upload

### DIFF
--- a/.github/workflows/upload-s3.yaml
+++ b/.github/workflows/upload-s3.yaml
@@ -1,0 +1,35 @@
+name: upload-s3
+on:
+  push:
+    branches:
+      - main
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.1
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3.1.1
+        with:
+          node-version: '16.x'
+      - name: Cache
+        uses: actions/cache@v3.0.2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Build
+        run: npm install && npm run export
+      - name: Upload
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'ap-northeast-2'
+          SOURCE_DIR: 'out'
+          DEST_DIR: 'customer-ui'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "export": "npm run build && next export",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
## New feature

- `main` 브랜치에 커밋하면 자동으로 Static file(HTML, js, etc) 빌드
    - 빌드하는 것은 `next build` 와 `next export` 명령어 이용
    - `package.json` 에 단축키 등록해놔서 `npm run export` 로 빌드 가능
    - `main` 브랜치에 푸쉬되는 개발의 결과물은 ***반드시*** 이 명령어로 Static file 로 빌드되어서 정상적으로 작동할 수 있어야 함
    - 참고 [공식문서](https://nextjs.org/docs/advanced-features/static-html-export)
- AWS S3 버킷에 업로드

## Related Issue

- @chopinballadeno4  맘에 들면 머지 부탁